### PR TITLE
fix: use onSavedArticlesPage instead of location.pathname

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -133,7 +133,7 @@ function App() {
         </Route>
         <ProtectedRoute path='/saved-articles' loggedIn={loggedIn}>
           <SavedNewsHeader />
-          <NewsCardList onSavedArticlesPage={onSavedArticlesPage} />
+          <NewsCardList onSavedArticlesPage={onSavedArticlesPage} loggedIn={loggedIn} />
         </ProtectedRoute>
       </Switch>
       <SignIn

--- a/src/components/news-card-list/NewsCardList.js
+++ b/src/components/news-card-list/NewsCardList.js
@@ -38,7 +38,7 @@ function NewsCardList( { onSavedArticlesPage }) {
           }`}
         >
           {displayedCards.map((newscard) => (
-            <NewsCard key={newscard.id} data={newscard} />
+            <NewsCard key={newscard.id} data={newscard} onSavedArticlesPage={onSavedArticlesPage} />
           ))}
         </div>
         {!onSavedArticlesPage && (

--- a/src/components/newsCard/NewsCard.js
+++ b/src/components/newsCard/NewsCard.js
@@ -1,10 +1,8 @@
-import React from 'react';
-import { useLocation } from 'react-router-dom';
+import React, { useState } from 'react';
 import './NewsCard.css';
 
-function NewsCard({data}) {
-  const location = useLocation();
-  const [isSaved, setIsSaved] = React.useState(false);
+function NewsCard({ data, onSavedArticlesPage }) {
+  const [isSaved, setIsSaved] = useState(false);
 
   function handleSave() {
     setIsSaved(!isSaved);
@@ -14,14 +12,14 @@ function NewsCard({data}) {
     <div className="news-card">
       <img src={data.image} alt={data.alt} className="news-card__image" />
 
-      {location.pathname === '/' && 
+      {!onSavedArticlesPage && 
       <>
         <button className={`news-card__button news-card__button_save ${isSaved ? "news-card__button_save_active" : ""}`} onClick={handleSave}></button>
         <div className="news-card__tooltip">Sign in to save articles</div>
       </>
       }
 
-      {location.pathname === '/saved-articles' &&
+      {onSavedArticlesPage &&
       <>
         <button className="news-card__button news-card__button_delete"></button>
         <div className="news-card__tooltip">Remove from saved</div>


### PR DESCRIPTION
Hello! 

I pushed the changes I made during our phone call. 
So instead of location.pathname I'm now using the onSavedArticlesPage hook to determine which cards design should load. 

However, the loggedIn status doesn't seem to work on the tooltip... Maybe we can look at this tomorrow?